### PR TITLE
Workday ADRs

### DIFF
--- a/doc/adr/0023-workday-integration-principles.md
+++ b/doc/adr/0023-workday-integration-principles.md
@@ -4,7 +4,7 @@ Date: 2018-10-10
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/doc/adr/0024-use-workday-api-to-manage-invoicing.md
+++ b/doc/adr/0024-use-workday-api-to-manage-invoicing.md
@@ -1,0 +1,63 @@
+# 24. Use Workday API to manage invoicing
+
+Date: 2018-11-07
+
+## Status
+
+Proposed
+
+## Context
+
+As outlined in [ADR-0023][adr-0023], CCS will be migrating their finance system
+to Workday in April 2019. As part of this migration, invoices sent to suppliers
+for the framework management fees will need to be created there rather in
+Coda. This means we need to change the process within Report MI.
+
+The principles set out in ADR-0023 state that we will use APIs for all communication
+between Report MI and Workday instead of batch exports and file transfers.
+
+### Workday API
+
+Workday provides an API for third-party systems to insert and add data
+to a tenant's system.
+
+There are many parts to the API, but there are two endpoints which are of
+particular interest to us for invoicing.
+
+- **Submit_Customer_Invoice** - this endpoint allows the creation (and replacement) of invoices within Workday.
+- **Get_Customer_Invoice** - this endpoint returns all the information about an invoicing including it's
+state and payment status.
+
+## Decision
+
+Report MI will use the Workday API to create invoices in Workday for the
+management fee. Report MI will talk directly to the Workday API, not through
+any intermediaries - this will reduce the number of moving parts and potential
+failure points.
+
+We will use the `Submit_Customer_Invoice` API endpoint to create a new invoice
+for each approved submission. As outlined in 0023, we will create one invoice
+per supplier, per commercial agreement, per month.
+
+If necessary, we will use this API endpoint to automatically create negative
+invoices (credit notes) and/or issue adjustments as required.
+
+All invoices created will be generated with a state of `Draft`.
+
+The unique identifier of the created invoice will be stored by Report MI for
+later use.
+
+We will use the `Get_Customer_Invoice` API endpoint to query the state of an
+invoice. We will use this to allow Report MI to show the status of issued
+invoices to suppliers.
+
+## Consequences
+
+The Workday team will need to provide API access to the Report MI team to enable
+this integration to operate. This will need to include appropriate
+pre-production environments to enable integration testing.
+
+Report MI team will need to develop features to handle the submission of
+invoices to the API.
+
+[adr-0023]: 0023-workday-integration-principles.md

--- a/doc/adr/0025-submit-invoices-to-workday-asyncronously.md
+++ b/doc/adr/0025-submit-invoices-to-workday-asyncronously.md
@@ -1,0 +1,45 @@
+# 25. Submit invoices to Workday asynchronously
+
+Date: 2018-11-07
+
+## Status
+
+Proposed
+
+## Context
+
+As discussed in [ADR-0023][adr-0023] and [ADR-0024][adr-0024], Report MI will be moving from generating a
+regular file extract to using the Workday API for creating management fee
+invoices.
+
+As we move to using the API, it becomes less important to batch up the creation
+of invoices, and we can move towards a more real-time operation.
+
+The generation of invoices is not part of the critical-path of a management
+information submission, so the creation of it shouldn't block or slow down the
+experience of suppliers making their return.
+
+As a result, the process for generating the invoice and submitting it to Workday
+should happen asynchronously from the rest of the submission.
+
+The best way of achieving this is to add completed tasks to a queue, and have
+the API interaction undertaken by a worker.
+
+## Decision
+
+The creation and submission of invoices to Workday will happen asynchronously
+using a queue/worker pattern.
+
+When a supplier task is completed, Report MI should add it to a queue. A worker
+should read from the queue, generate the invoice and submit to the Workday API.
+
+If the Workday API is unavailable, or an error occurs, the submission should be
+retried. After a (to be defined) number of retries, this should be reported for
+investigation.
+
+## Consequences
+
+Report MI will need to produce the queue/worker process and define how errors are handled.
+
+[adr-0023]: 0023-workday-integration-principles.md
+[adr-0024]: 0024-use-workday-api-to-manage-invoicing.md


### PR DESCRIPTION
**Do not merge until after TDDA on Monday 12 November**

New ADRs to describe how the integration between Report MI and Workday will operate.

0024: we will use the Workday API to submit invoices
0025: we will submit invoices asynchronously
