### PR TITLE
Document the data warehouse export

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -2,5 +2,5 @@
 * [About the Service](README.md)
 * [Language](language.md)
 * [Validations](validations.md)
+* [Data Warehouse Export](data-warehouse-export.md)
 * [Decision Records](decision-records.md)
-

--- a/docs/data-warehouse-export.md
+++ b/docs/data-warehouse-export.md
@@ -1,0 +1,10 @@
+# Data Warehouse Export
+
+To enable CCS to perform deeper analysis and reporting on submission data, the
+RMI application generates an export of various data related to tasks and their
+submissions.
+
+There are four export files that are generated: tasks; submissions; invoices;
+contracts.
+
+See the [Data Warehouse Documentation](https://github.com/dxw/DataSubmissionServiceAPI/blob/develop/docs/data-warehouse-export.md) for a full outline of the data being exported.


### PR DESCRIPTION
This was requested so that admin users can understand what data is
available to them in the data warehouse so that they know what they find
there when the RMI admin interface doesn't show them what they need.